### PR TITLE
修复当用户提供-o参数时，会出现套娃创建文件夹的bug

### DIFF
--- a/baby_mht_image_extractor.py
+++ b/baby_mht_image_extractor.py
@@ -49,10 +49,14 @@ def get_boundary_chrome(f):
 
 
 def make_dir(floder_name):
-    PATH = os.path.join(OUT_PATH, floder_name)
+    if "-o" not in sys.argv:
+        PATH = os.path.join(OUT_PATH, floder_name)
+    else:
+        PATH = floder_name
     if not os.path.exists(PATH):
         os.makedirs(PATH)
-        os.chdir(PATH)
+        if "-o" in sys.argv:
+            os.chdir(PATH)
     return PATH
 
 

--- a/baby_mht_image_extractor.py
+++ b/baby_mht_image_extractor.py
@@ -55,7 +55,7 @@ def make_dir(floder_name):
         PATH = floder_name
     if not os.path.exists(PATH):
         os.makedirs(PATH)
-        if "-o" in sys.argv:
+        if "-o" not in sys.argv:
             os.chdir(PATH)
     return PATH
 


### PR DESCRIPTION
1. sub_path_name已经拼接过OUT_PATH(-o参数提供的输出路径)，当用户提供-o参数时，创建文件夹时无需拼接
2. 当存在-o参数时，创建文件夹如果使用os.chdir切换工作目录，则会出现套娃创建目录的bug。